### PR TITLE
Minor accessibility improvements

### DIFF
--- a/generators.html
+++ b/generators.html
@@ -66,9 +66,8 @@
     <article class=generator>
       <img class=generator-image src=>
       <div class=meta>
-        <h2 class=title></h2>
+        <a class=link href=><h2 class=title></h2></a>
         <p class=author></p>
-        <p><a class=link href=>Link</a></p>
       </div>
     </article>
   </template>
@@ -86,8 +85,8 @@
       const p = template.content.cloneNode(true)
 
       p.querySelector('h2.title').textContent = d.title
-      p.querySelector('p.author').textContent = '@ ' + d.author
       p.querySelector('a.link').href = d.link
+      p.querySelector('p.author').textContent = '@ ' + d.author
       p.querySelector('img.generator-image').src = d.image
 
       projects.appendChild(p)

--- a/generators.html
+++ b/generators.html
@@ -64,7 +64,7 @@
   <h1>Community generators</h1>
   <template id=generator>
     <article class=generator>
-      <img class=generator-image src=>
+      <img class=generator-image alt="" src=>
       <div class=meta>
         <a class=link href=><h2 class=title></h2></a>
         <p class=author></p>

--- a/generators.html
+++ b/generators.html
@@ -66,7 +66,7 @@
   <template id=generator>
     <article class=generator>
       <a class=generator-image-link>
-        <img class=generator-image aria-hidden=true alt= src=>
+        <img class=generator-image aria-hidden=true alt="" src=>
       </a>
       <div class=meta>
         <a class=link href=><h2 class=title></h2></a>
@@ -92,7 +92,6 @@
       p.querySelector('p.author').textContent = '@ ' + d.author
       p.querySelector('a.generator-image-link').href = d.link
       p.querySelector('img.generator-image').src = d.image
-      p.querySelector('img.generator-image').alt = d.title
 
       projects.appendChild(p)
     }

--- a/generators.html
+++ b/generators.html
@@ -38,7 +38,7 @@
       margin: initial;
     }
 
-    article.generator>img {
+    article.generator>a>img {
       width: 200px;
       height: 200px;
       object-fit: cover;
@@ -51,7 +51,8 @@
         font-size: 70%;
       }
 
-      article.generator>img {
+      article.generator>a>img {
+        max-width: inherit;
         width: 100px;
         height: 100px;
       }
@@ -64,7 +65,9 @@
   <h1>Community generators</h1>
   <template id=generator>
     <article class=generator>
-      <img class=generator-image alt="" src=>
+      <a class=generator-image-link>
+        <img class=generator-image alt= src=>
+      </a>
       <div class=meta>
         <a class=link href=><h2 class=title></h2></a>
         <p class=author></p>
@@ -87,7 +90,9 @@
       p.querySelector('h2.title').textContent = d.title
       p.querySelector('a.link').href = d.link
       p.querySelector('p.author').textContent = '@ ' + d.author
+      p.querySelector('a.generator-image-link').href = d.link
       p.querySelector('img.generator-image').src = d.image
+      p.querySelector('img.generator-image').alt = d.title
 
       projects.appendChild(p)
     }

--- a/generators.html
+++ b/generators.html
@@ -66,7 +66,7 @@
   <template id=generator>
     <article class=generator>
       <a class=generator-image-link>
-        <img class=generator-image alt= src=>
+        <img class=generator-image aria-hidden=true alt= src=>
       </a>
       <div class=meta>
         <a class=link href=><h2 class=title></h2></a>


### PR DESCRIPTION
- [x] Removes unintuitive & duplicated "link" links - screenreaders can be used to scan the page for links without reading other content to make navigating them easier. General rules of thumb for writing useful links:
1. avoid duplication
2. provide context in the link title. Avoid "click me" or "link".

Using the header also means that the link target is easier to tap on mobile devices.
[Yale university discussion of link text context](https://usability.yale.edu/web-accessibility/articles/links#link-text)

- [x] Makes the image clickable, hides this from screenreaders. General usability improvement, avoids duplication as per point 1 above
- [x] Marks images as decorative with `alt=""` as their context is given by supporting text, and it's still possible to force screenreaders onto them anyway; just a failsafe. [W3 examples of how to use decorative alt text](https://www.w3.org/WAI/tutorials/images/decorative/)

![Desktop Screenshot 2022 05 01 - 22 53 40 05](https://user-images.githubusercontent.com/45462299/166166048-ae167f60-1f39-4f64-9a3d-716eb32843ef.png)
![Desktop Screenshot 2022 05 01 - 22 53 49 42](https://user-images.githubusercontent.com/45462299/166166051-a0782956-d16e-4e09-9196-f5cba549f864.png)
